### PR TITLE
Fix ListTag to display via Tag index

### DIFF
--- a/src/main/java/seedu/address/ui/TagCard.java
+++ b/src/main/java/seedu/address/ui/TagCard.java
@@ -28,7 +28,8 @@ public class TagCard extends UiPart<Region> {
         super(FXML);
         this.tag = tag;
 
-        id.setText(displayedIndex + ". ");
+        /** The number shown will be the Tags ID */
+        id.setText(tag.getId() + ". ");
 
         TagName tagName = (TagName) tag.getName();
         Label label = new Label(tagName.toString());


### PR DESCRIPTION
Resolves #50 
ListTag should now display the ids of each tag, instead of a default indexing.